### PR TITLE
Issue #17: Show mappings found when bot starts

### DIFF
--- a/src/oneview.js
+++ b/src/oneview.js
@@ -31,8 +31,9 @@ import configLoader from './config-loader';
 const main = (robot) => {
   // load OneView configuration data from external file
   let oneviewConfig = configLoader(robot);
-  if(oneviewConfig == null) {
-    robot.logger.error('OneView config file not found!  Bot will not be started.');
+  if (oneviewConfig == null) {
+    robot.logger.error(
+      'OneView config file not found!  Bot will not be started.');
     return;
   }
 
@@ -48,10 +49,26 @@ const main = (robot) => {
     robot.logger.info('Logged into OV appliance.');
     new ovBrain(client, robot, Lexer);
     ovListener(robot, client);
-    // Introduce robot after the brain has been built
-    robot.messageRoom('#' + client.notificationsRoom, "Hello, I'm " + robot.name + "!"
-      +  " How can I assist you? Type '@" + robot.name + " help' to learn what I can do.");
+    introBot();
   }); //end login
+
+  function introBot() {
+    client.ServerHardware.getAllServerHardware().then((sh) => {
+      client.ServerProfiles.getAllServerProfiles().then((sp) => {
+        client.ServerProfileTemplates.getAllServerProfileTemplates()
+          .then((spt) => {
+            robot.messageRoom('#' + client.notificationsRoom,
+              "Hello, I'm " + robot.name + "! "
+              +"Your OneView instance is currently showing:"
+              + "\n\t\u2022" + sh.members.length + " server(s)"
+              + "\n\t\u2022" + sp.members.length + " server profile(s)"
+              + "\n\t\u2022" + spt.members.length +" server profile template(s)"
+              + "\nHow can I assist you? Type '@" + robot.name
+              + " help' to learn what I can do.");
+          });
+      });
+    });
+  }
 
   //TODO: Bug #22 Not working.  Need to perform an aysnc shutdown from the SCMB
   function exitHandler() {

--- a/src/ov-brain.js
+++ b/src/ov-brain.js
@@ -33,6 +33,7 @@ export default class OneViewBrain {
           Lexer.addNamedDevice(sh.name, sh.uri, 'name');
           Lexer.addNamedDevice(sh.serialNumber, sh.uri, 'serialNumber');
           robot.brain.set("__hpe__" + sh.uri, {uri:sh.uri, keys:{name:sh.name, serialNumber: sh.serialNumber}});
+          robot.logger.info('Found server hardware: (Name: ' + sh.name + ', Serial Number: ' + sh.serialNumber + ', URI: ' + sh.uri + ')');
         }
       }
     }).catch(error, robot);
@@ -45,6 +46,7 @@ export default class OneViewBrain {
           if (sp.serialNumberType === 'Virtual') {
             Lexer.addNamedDevice(sp.serialNumber, sp.uri, 'serialNumber');
           }
+          robot.logger.info('Found server profile: (Name: ' + sp.name + ', URI: ' + sp.uri + ')');
           //robot.brain.set("__hpe__" + sh.uri, {uri:sh.uri, keys:{name:sh.name, serialNumber: sh.serialNumber}});
         }
       }
@@ -55,6 +57,7 @@ export default class OneViewBrain {
         for (var i = 0; i < res.members.length; i++) {
           const spt = res.members[i];
           Lexer.addNamedDevice(spt.name, spt.uri, 'name');
+          robot.logger.info('Found server profile template: (Name: ' + spt.name + ', URI: ' + spt.uri + ')');
           //robot.brain.set("__hpe__" + sh.uri, {uri:sh.uri, keys:{name:sh.name, serialNumber: sh.serialNumber}});
         }
       }


### PR DESCRIPTION
Printing out SH/SP/SPT mappings when discovered, both in logs and a simple summary for the user:

![2017-03-24 16_48_57-slack - oneview hubot](https://cloud.githubusercontent.com/assets/7452848/24316202/d5d94218-10b1-11e7-83b1-2c08470f8fb3.png)
