### PR TITLE
Adding the server hardware's interconnect URI

### DIFF
--- a/src/oneview-sdk/utils/enhance.js
+++ b/src/oneview-sdk/utils/enhance.js
@@ -78,9 +78,24 @@ export default class ResourceEnhancer {
           }
         }
       });
+      if (obj.type && obj.type.toLowerCase().startsWith('server-hardware')) {
+        this.__addSHInterconnectDowlinkHyperlinks__(obj);
+      }
     }
-
     return obj;
+  }
+
+  __addSHInterconnectDowlinkHyperlinks__(obj){
+    if (obj.portMap && obj.portMap.deviceSlots) {
+      for (let slot of obj.portMap.deviceSlots) {
+        if (slot.physicalPorts && slot.physicalPorts.length > 0) {
+          for (let physicalPort of slot.physicalPorts) {
+            let icKey = 'serverInterconnectPort' + physicalPort.portNumber + 'Hyperlink';
+            obj[icKey] = 'https://' + this.host + physicalPort.physicalInterconnectUri + '/statistics/d' + physicalPort.interconnectPort;
+          }
+        }
+      }
+    }
   }
 
   __guiRoute__(uri) {

--- a/src/test/enhance.js
+++ b/src/test/enhance.js
@@ -98,4 +98,43 @@ describe('ResourceEnhancer', () => {
       uri: '/rest/tasks/resourceID',
       hyperlink: 'https://localhost/#/activity/r/rest/tasks/resourceID?s_sid=authtoken' });
   });
+
+  it('addSHInterconnectDowlinkHyperlinks 1 port', () => {
+    let body = {
+      type: 'server-hardware',
+      portMap: {
+        deviceSlots: [{
+          physicalPorts: [{
+            interconnectPort: 9,
+            portNumber: 1,
+            physicalInterconnectUri: '/rest/interconnects/id1'
+          }]
+        }]
+      }
+    };
+    let result = resourceEnhancer.transformHyperlinks('authtoken', body);
+    chai.expect(result).to.deep.equal(body);
+  });
+
+  it('addSHInterconnectDowlinkHyperlinks 2 ports', () => {
+    let body = {
+      type: 'server-hardware',
+      portMap: {
+        deviceSlots: [{
+          physicalPorts: [{
+            interconnectPort: 9,
+            portNumber: 1,
+            physicalInterconnectUri: '/rest/interconnects/id1'
+          },
+          {
+            interconnectPort: 9,
+            portNumber: 2,
+            physicalInterconnectUri: '/rest/interconnects/id2'
+          }]
+        }]
+      }
+    };
+    let result = resourceEnhancer.transformHyperlinks('authtoken', body);
+    chai.expect(result).to.deep.equal(body);
+  });
 });


### PR DESCRIPTION
For issue #71

This first patch adds the server hardware's interconnect URI information to the internal server hardware resource.  We can use this URI to build the network utilization graph for the server hardware.