### PR TITLE
Pass in http(s)_proxy variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@
 
 FROM jesseolsen/core-hubot:latest
 
-ARG PROXY
-
 COPY docker_entry.sh /usr/local/bin/
 COPY docker_go.sh /go.sh
 COPY . /home/docker/hubot-org/

--- a/Dockerfile-core
+++ b/Dockerfile-core
@@ -22,11 +22,8 @@ USER root
 #http://askubuntu.com/questions/506158/unable-to-initialize-frontend-dialog-when-using-ssh
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG PROXY
-ENV http_proxy http://$PROXY
-ENV https_proxy http://$PROXY
-ENV HTTP_PROXY http://$PROXY
-ENV HTTPS_PROXY http://$PROXY
+ARG http_proxy
+ARG https_proxy
 
 # Steps from:
 # https://github.com/HewlettPackard/hpe-oneview-hubot/wiki/Getting-Started
@@ -57,11 +54,6 @@ RUN npm install -g yo generator-hubot
 
 ###############################################################################
 USER docker
-
-ENV http_proxy http://$PROXY
-ENV https_proxy http://$PROXY
-ENV HTTP_PROXY http://$PROXY
-ENV HTTPS_PROXY http://$PROXY
 
 RUN npm config set proxy $http_proxy
 RUN npm config set http-proxy $http_proxy
@@ -111,11 +103,6 @@ USER root
 # 4. Install gulp (etc.)
 
 WORKDIR /home/docker/hubot-core-org
-
-ENV http_proxy http://$PROXY
-ENV https_proxy http://$PROXY
-ENV HTTP_PROXY http://$PROXY
-ENV HTTPS_PROXY http://$PROXY
 
 # To install avoid cross-device link not permitted...
 RUN cd /usr/lib/node_modules/npm; npm install fs-extra;        \

--- a/core_docker_build.sh
+++ b/core_docker_build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -f Dockerfile-core --build-arg=PROXY=$PROXY -t docker.io/jesseolsen/core-hubot:latest .
+docker build -f Dockerfile-core --build-arg=http_proxy=$http_proxy --build-arg=https_proxy=$https_proxy -t docker.io/jesseolsen/core-hubot:latest .


### PR DESCRIPTION
Before we were passing in PROXY and always
assigning https_proxy and http_proxy based on these values,
but then when no proxy is used, these are still passed in.

This change makes it so that docker builds will
pass with our without a proxy.