### PR TITLE
Add support for Flowdock

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To get started with this project please read the [getting started WIKI](https://
 * Visualize HPE OneView hardware utilization
 * Support for HPE OneView push notifications and alerts
 * Support for multiple OneView appliances
-* Rich support for Slack and HipChat
+* Rich support for Slack, HipChat and Flowdock
 
 ![HPE OneView Hubot in Slack](/screenshots/slack-dashboard.PNG?raw=true)
 ![HPE OneView Hubot in Slack](/screenshots/slack-mobile.png?raw=true)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/HewlettPackard/hpe-oneview-hubot/issues"
   },
   "dependencies": {
+    "hubot-flowdock": ">= 0.0.1",
     "amqp": "^0.2.6",
     "d3": "^4.2.7",
     "fuzzyset.js": "0.0.1",

--- a/src/listener/utils/resource-transforms.js
+++ b/src/listener/utils/resource-transforms.js
@@ -23,6 +23,7 @@ THE SOFTWARE.
 import HipChatTransform from './transforms/hipchat';
 import ShellTransform from './transforms/shell';
 import SlackTransform from './transforms/slack';
+import FlowdockTransform from './transforms/flowdock';
 
 //From: http://stackoverflow.com/questions/591857/how-can-i-get-a-javascript-stack-trace-when-i-throw-an-exception
 function st() {
@@ -59,6 +60,8 @@ export default class ResourceTransforms {
       this.provider = new SlackTransform();
     } else if (robot.adapterName === 'hipchat') {
       this.provider = new HipChatTransform();
+    } else if (robot.adapterName == 'flowdock') {
+      this.provider = new FlowdockTransform();
     } else {
       this.provider = new ShellTransform();
     }

--- a/src/listener/utils/transforms/alert.js
+++ b/src/listener/utils/transforms/alert.js
@@ -34,6 +34,23 @@ export default class Alert extends Resource {
     }
   }
 
+  buildFlowdockOutput() {
+    let output = '';
+    for (const field in this) {
+      if (this.__isNonDisplayField__(field) || !this[field]) {
+        continue;
+      }
+      if (field === 'associatedResource') {
+        output += '\t\u2022 Resource: ' + this[field].resourceName + '\n';
+      } else {
+        output += '\t\u2022 ' + this.camelCaseToTitleCase(field) + ': ' + this[field] + '\n';
+      }
+    }
+    //Add status to output only for Flowdock
+    output += '\t\u2022 Severity: ' +  this.severity + '\n';
+    return output;
+  }
+
   buildSlackFields() {
     let fields = [];
     for (const field in this) {

--- a/src/listener/utils/transforms/flowdock.js
+++ b/src/listener/utils/transforms/flowdock.js
@@ -1,0 +1,142 @@
+/*
+(c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { transform } from './resource-transformer';
+const url = require('url');
+
+function Title(resource) {
+  if (resource.type) {
+    if (resource.type.startsWith('AlertResource')) {
+      if (resource.alertTypeID && resource.alertTypeID.startsWith("Trap")) {
+        return "Trap: " + resource.description;
+      }
+      return resource.description + '\n';
+    }
+
+    if (resource.type.startsWith('server-hardware')) {
+      return 'Server Hardware: ' + resource.name + '\n';
+    }
+
+    if (resource.type.startsWith('ServerProfileTemplate')) {
+      return 'Profile Template: ' + resource.name + '\n';
+    }
+
+    if (resource.type.startsWith('ServerProfile') && !resource.type.startsWith('ServerProfileCompliancePreview')) {
+      return 'Profile: ' + resource.name + '\n';
+    }
+  }
+}
+
+function ToOutput(resource) {
+  const transformedRes = transform(resource);
+  let host;
+  if (resource.hyperlink) {
+    host = url.parse(resource.hyperlink).hostname;
+  }
+
+  const title = Title(transformedRes);
+
+  let output = '';
+  if (title) {
+    output = title;
+  }
+  if(transformedRes.pretext) {
+    output += transformedRes.pretext + '\n';
+  }
+  output += transformedRes.buildFlowdockOutput(host);
+  return output;
+}
+
+function output(resource) {
+  if (Array.isArray(resource)) {
+    return resource.map(ToOutput);
+  } else if (resource.members) {
+    return resource.members.map(ToOutput);
+  } else {
+    return [ToOutput(resource)];
+  }
+  return [];
+}
+
+export default class FlowdockTransform {
+  hyperlink(uri, name) {
+    return name ? name : uri;
+  }
+
+  list(lines) {
+    for (var i = 0; i < lines.length; i++) {
+      lines[i] = '  - ' + lines[i];
+    }
+    return lines;
+  }
+
+  text(msg, text) {
+    msg.send(text);
+  }
+
+  send(msg, resource, text) {
+    if (!resource) {
+      throw "Resource was null";
+    }
+
+    const out = output(resource).join('\n');
+    if (text) {
+      msg.send(out);
+    }
+
+    msg.send(out);
+  }
+
+  messageRoom(robot, room, resource, text) {
+    if (text) {
+      robot.messageRoom(room, text);
+    }
+
+    if (resource) {
+      const out = output(resource).join('\n');
+      robot.messageRoom(room, out);
+    }
+  }
+
+  error(msg, err) {
+    let userError = "Oops there was a problem.\n\n";
+    if (err.error.errorCode) {
+      userError = userError.concat("OneView error code: ").concat(err.error.errorCode).concat("\n");
+    }
+    if (err.error.details) {
+      userError = userError.concat(err.error.details).concat("\n");
+    }
+    if (err.error.message) {
+      userError = userError.concat(err.error.message).concat("\n");
+    }
+    if (err.error.recommendedActions && Object.prototype.toString.call(err.error.recommendedActions) === '[object Array]') {
+      err.error.recommendedActions.forEach(function(recommendedAction) {
+        userError = userError.concat(recommendedAction).concat("\n");
+      });
+    }
+    msg.send(userError);
+  }
+
+  getProviderName() {
+    return 'Flowdock';
+  }
+}

--- a/src/listener/utils/transforms/server-hardware.js
+++ b/src/listener/utils/transforms/server-hardware.js
@@ -36,6 +36,28 @@ export default class ServerHardware extends Resource {
     }
   }
 
+  buildFlowdockOutput(host) {
+    let output = '';
+    let hasProfile = false;
+    for (const field in this) {
+      if (this.__isNonDisplayField__(field) || !this[field]) {
+        continue;
+      }
+      output += '\t\u2022 ' + this.camelCaseToTitleCase(field) + ': ' + this[field] + '\n';
+    }
+    if (this.serverProfileUri) {
+      output += '\t\u2022 Profile: ' +  getDeviceNameAndHyperLink(host + this.serverProfileUri).deviceName + '\n';
+      hasProfile = true;
+    }
+    if (!hasProfile) {
+      output += '\t\u2022 Profile: Available for deployment\n';
+    }
+    //Add status to output only for Flowdock
+    output += '\t\u2022 Status: ' +  this.status + '\n';
+
+    return output;
+  }
+
   buildSlackFields(host) {
     let fields = [];
     let hasProfile = false;

--- a/src/listener/utils/transforms/server-profile-compliance-preview.js
+++ b/src/listener/utils/transforms/server-profile-compliance-preview.js
@@ -36,6 +36,25 @@ export default class ServerProfileCompliancePreview extends Resource {
     }
   }
 
+  buildFlowdockOutput() {
+    let output = '';
+    for (const field in this) {
+      if (this.__isNonDisplayField__(field) || !this[field]) {
+        continue;
+      }
+      let value = '';
+      if (Array.isArray(this[field])) {
+        value = this[field].join("\n");
+      } else {
+        value = this[field];
+      }
+      if (value) {
+        output += this.camelCaseToTitleCase(field) + ':\n' + value + '\n';
+      }
+    }
+    return output;
+  }
+
   buildSlackFields() {
     let fields = [];
     for (const field in this) {

--- a/src/listener/utils/transforms/server-profile-template.js
+++ b/src/listener/utils/transforms/server-profile-template.js
@@ -32,6 +32,17 @@ export default class ServerProfileTemplate extends Resource {
     }
   }
 
+  buildFlowdockOutput() {
+    let output = '';
+    for (const field in this) {
+      if (this.__isNonDisplayField__(field) || !this[field]) {
+        continue;
+      }
+      output += '\t\u2022 ' + this.camelCaseToTitleCase(field) + ': ' + this[field] + '\n';
+    }
+    return output;
+  }
+
   buildSlackFields() {
     let fields = [];
     for (const field in this) {

--- a/src/listener/utils/transforms/server-profile.js
+++ b/src/listener/utils/transforms/server-profile.js
@@ -36,6 +36,23 @@ export default class ServerProfile extends Resource {
     }
   }
 
+  buildFlowdockOutput(host) {
+    let output = '';
+    for (const field in this) {
+      if (this.__isNonDisplayField__(field) || !this[field]) {
+        continue;
+      }
+      output += '\t\u2022 ' + this.camelCaseToTitleCase(field) + ': ' + this[field] + '\n';
+    }
+    if (this.serverHardwareUri) {
+      output += '\t\u2022 Server Hardware: ' + getDeviceNameAndHyperLink(host + this.serverHardwareUri).deviceName + '\n';
+      output += '\t\u2022 Hardware Model: ' + getHardwareModel(host + this.serverHardwareUri) + '\n';
+    }
+    //Add status to output only for Flowdock
+    output += '\t\u2022 Status: ' +  this.status + '\n';
+    return output;
+  }
+
   buildSlackFields(host) {
     let fields = [];
     for (const field in this) {

--- a/src/oneview.js
+++ b/src/oneview.js
@@ -55,7 +55,15 @@ const main = (robot) => {
       client.ServerProfiles.getAllServerProfiles().then((sp) => {
         client.ServerProfileTemplates.getAllServerProfileTemplates()
           .then((spt) => {
-            robot.messageRoom('#' + client.notificationsRoom,
+            let room = '';
+
+            if (robot.adapterName === 'flowdock') {
+              room = client.notificationsRoom;
+            } else {
+              room = '#' + client.notificationsRoom;
+            }
+
+            robot.messageRoom(room,
               "Hello, I'm " + robot.name + "! "
               +"Your OneView instance is currently showing:"
               + BULLET + sh.members.length + " server(s)."


### PR DESCRIPTION
Closes #13.

- Operations like show dashboard and utilization don't supported yet (we need to discover how to use the Flowdock adapter to upload PNG's).
- Don't supports message attachments just like Slack, only plain text like HipChat.
- 'Transforms' need refactoring (to open another issue about that).
- All other operation works fine!!!

![flowdock](https://user-images.githubusercontent.com/26657147/31642297-9f6b5dae-b2c0-11e7-924c-305472ef6db5.png)
