### PR TITLE
Fixing TLS erros

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "url": "https://github.com/HewlettPackard/hpe-oneview-hubot/issues"
   },
   "dependencies": {
-    "hubot-flowdock": ">= 0.0.1",
     "amqp": "^0.2.6",
     "d3": "^4.2.7",
     "fuzzyset.js": "0.0.1",
+    "https": "^1.0.0",
     "hubot-conversation": "^1.1.1",
+    "hubot-flowdock": ">= 0.0.1",
     "jsdom": "^9.8.0",
     "nlp_compromise": "^6.5.0",
     "request": "^2.75.0",

--- a/src/oneview-sdk/connection.js
+++ b/src/oneview-sdk/connection.js
@@ -21,12 +21,10 @@ THE SOFTWARE.
 */
 
 import request from 'request-promise';
+import https from 'https';
 import PromiseFeedback from './utils/emitter';
 import Enhance from './utils/enhance';
 import { isTerminal } from './tasks';
-
-//TODO this is global to the NodeJS process we probably want to figure out a cleaner way to do this
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 var useProxy = false;
 
@@ -41,6 +39,8 @@ export default class Connection {
       'Content-Type': 'application/json',
       'auth': ''
     };
+
+    this.agent = new https.Agent({rejectUnauthorized: false});
 
     if (doProxy) {
       useProxy = true;
@@ -65,7 +65,8 @@ export default class Connection {
       uri: 'https://' + this.host + path,
       json: true,
       headers: this.headers,
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+      agent: this.agent
     };
 
     if (filter) {
@@ -86,8 +87,10 @@ export default class Connection {
       json: true,
       headers: this.headers,
       body: this.enhance.removeHyperlinks(body),
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+      agent: this.agent
     });
+    
   }
 
   put(path, body) {
@@ -101,7 +104,8 @@ export default class Connection {
       json: true,
       headers: this.headers,
       body: this.enhance.removeHyperlinks(body),
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+      agent: this.agent
     });
   }
 
@@ -116,7 +120,8 @@ export default class Connection {
       json: true,
       headers: this.headers,
       body: this.enhance.removeHyperlinks(body),
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+      agent: this.agent
     });
   }
 
@@ -130,7 +135,8 @@ export default class Connection {
       uri: 'https://' + this.host + path,
       json: true,
       headers: this.headers,
-      resolveWithFullResponse: true
+      resolveWithFullResponse: true,
+      agent: this.agent
     });
   }
 
@@ -187,7 +193,8 @@ export default class Connection {
       method: 'GET',
       json: true,
       headers: this.headers,
-      uri: 'https://' + this.host + uri
+      uri: 'https://' + this.host + uri,
+      agent: this.agent
     });
   }
 
@@ -221,7 +228,8 @@ export default class Connection {
    let resourceUri = task.associatedResource.resourceUri;
    const fetch = {
      method: 'GET', json: true, headers: this.headers,
-     uri: 'https://' + this.host + task.uri
+     uri: 'https://' + this.host + task.uri,
+     agent: this.agent
    };
 
    if (isTerminal(task)) {


### PR DESCRIPTION
Closes #5. Changes on the Connection class to avoid TLS erros.

- HTTPS dependency added on package.json.
- Created Agent with `rejectUnauthorized: false` to limit the security vulnerability.

Solution: https://stackoverflow.com/questions/20433287/node-js-request-cert-has-expired#answer-29397100